### PR TITLE
Added constant definitions for board properly re-size

### DIFF
--- a/Snake/Core/Food.cs
+++ b/Snake/Core/Food.cs
@@ -39,9 +39,9 @@ namespace Game.Core
                 App.EnableBonus();
             }
 
-            for (int y = 0; y < 30; y++)
+            for (int y = 0; y < Panel.PanelCorY; y++)
             {
-                for (int x = 0; x < 30; x++)
+                for (int x = 0; x < Panel.PanelCorX; x++)
                 {
                     if (Panel.GetBoxColor(x, y) == Color.Blue || Panel.GetBoxColor(x, y) == Color.Green)
                     {
@@ -60,8 +60,8 @@ namespace Game.Core
                 foundBox = false;
                 while (foundBox == false)
                 {
-                    foodXPos = R.Next(0, 30);
-                    foodYPos = R.Next(0, 30);
+                    foodXPos = R.Next(0, Panel.PanelCorX);
+                    foodYPos = R.Next(0, Panel.PanelCorY);
 
                     if (Panel.GetBoxColor(foodXPos, foodYPos) == Color.Black)
                     {
@@ -70,8 +70,8 @@ namespace Game.Core
                     }
                     else
                     {
-                        foodXPos = R.Next(0, 30);
-                        foodYPos = R.Next(0, 30);
+                        foodXPos = R.Next(0, Panel.PanelCorX);
+                        foodYPos = R.Next(0, Panel.PanelCorY);
                     }
                 }
             }
@@ -84,8 +84,8 @@ namespace Game.Core
                 {
                     foundBox = false;
 
-                    foodXPos = R.Next(0, 30);
-                    foodYPos = R.Next(0, 30);
+                    foodXPos = R.Next(0, Panel.PanelCorX);
+                    foodYPos = R.Next(0, Panel.PanelCorY);
 
                     if (Panel.GetBoxColor(foodXPos, foodYPos) == Color.Black)
                     {
@@ -94,8 +94,8 @@ namespace Game.Core
                     }
                     else
                     {
-                        foodXPos = R.Next(0, 30);
-                        foodYPos = R.Next(0, 30);
+                        foodXPos = R.Next(0, Panel.PanelCorX);
+                        foodYPos = R.Next(0, Panel.PanelCorY);
                     }
                 }
 

--- a/Snake/Core/Panel.cs
+++ b/Snake/Core/Panel.cs
@@ -10,30 +10,52 @@ namespace Game.Core
 {
     class Panel
     {
-        PictureBox[,] Box;
+
+        // Change this to the ratio value to increase/decrease the Panel's size 
+        // The "Size" goes from 0 to 12
+        public static int Size = 5;
+        public static int[] SizeOffset = {1,2,4,5,10,20,25,50,100,125,250,500};
+
+        // Declare statically to initialize the panel
+        public static int PanelSize = SizeOffset[Size];
+        public static int PanelBoardSize = 500;
+
+        // Starting point to fit  the panel to the Border
+        public static int StartingXPoint = 29;
+        public static int StartingYPoint = 107;
+  
+        // Define the unit size and the panel coordinate index amount
+        public static int PanelUnitSize = PanelBoardSize / PanelSize;
+        public static int PanelCorX = PanelSize;
+        public static int PanelCorY = PanelSize;
+        public static int CenterPoint = PanelSize / 2;
+
+        System.Windows.Forms.Panel[,] Box;
         main Game;
         Snake Snake;
 
         public Panel(main ptr)
         {
-            Game = ptr;
-            Box = new PictureBox[30, 30];
 
-            for (int y = 0; y < 30; y++)
+            Game = ptr;
+            Box = new System.Windows.Forms.Panel[PanelCorX, PanelCorY];
+
+            for (int y = 0; y < PanelCorY; y++)
             {
-                for (int x = 0; x < 30; x++)
+                for (int x = 0; x < PanelCorX; x++)
                 {
-                    Box[x, y] = new PictureBox();
-                    Box[x, y].Left = 36 + x * 16;
-                    Box[x, y].Top = 114 + y * 16;
-                    Box[x, y].Width = 17;
-                    Box[x, y].Height = 17;
+                    Box[x, y] = new System.Windows.Forms.Panel();
+                    Box[x, y].Left = StartingXPoint + x * PanelUnitSize;
+                    Box[x, y].Top = StartingYPoint + y * PanelUnitSize;
+                    Box[x, y].Width = PanelUnitSize;
+                    Box[x, y].Height = PanelUnitSize;
                     Box[x, y].BackColor = Color.Black;
                     Box[x, y].BorderStyle = BorderStyle.None;
-                    Game.AddControl(Box[x, y]);     
+                    Game.AddControl(Box[x, y]);                 
+                    
                 }
             }
-            Box[15, 15].BackColor = Color.Red;
+            Box[1, 1].BackColor = Color.Red;
         }
 
         public void AddSnake(Snake snake)
@@ -43,9 +65,9 @@ namespace Game.Core
 
         public void Render()
         {
-            for (int y = 0; y < 30; y++)
+            for (int y = 0; y < PanelCorY; y++)
             {
-                for (int x = 0; x < 30; x++)
+                for (int x = 0; x < PanelCorX; x++)
                 {
                     if (!(GetBoxColor(x, y) == Color.Blue || GetBoxColor(x, y) == Color.Green))
                     {
@@ -65,9 +87,9 @@ namespace Game.Core
 
         public void Reset()
         {
-            for (int y = 0; y < 30; y++)
+            for (int y = 0; y < PanelCorY; y++)
             {
-                for (int x = 0; x < 30; x++)
+                for (int x = 0; x < PanelCorX; x++)
                 {
                     SetBoxColor(x, y, Color.Black);
                 }
@@ -76,7 +98,7 @@ namespace Game.Core
 
         public void SetBoxColor(int x, int y, Color color)
         {
-            if (Snake.snakeHeadXPos < 0 || Snake.snakeHeadXPos > 29 || Snake.snakeHeadYPos < 0 || Snake.snakeHeadYPos > 29)
+            if (Snake.snakeHeadXPos < 0 || Snake.snakeHeadXPos >= PanelSize || Snake.snakeHeadYPos < 0 || Snake.snakeHeadYPos >= PanelSize)
                 Game.EndGame();
             else
                 Box[x, y].BackColor = color;

--- a/Snake/Core/Snake.cs
+++ b/Snake/Core/Snake.cs
@@ -22,10 +22,10 @@ namespace Game.Core
             Panel = panel;
             snakeHeadXPositions = new int[100];
             snakeHeadYPositions = new int[100];
-            snakeHeadXPos = 15;
-            snakeHeadYPos = 15;
-            snakeHeadXPositions[1] = 15;
-            snakeHeadYPositions[1] = 15;
+            snakeHeadXPos = Panel.CenterPoint;
+            snakeHeadYPos = Panel.CenterPoint;
+            snakeHeadXPositions[1] = Panel.CenterPoint;
+            snakeHeadYPositions[1] = Panel.CenterPoint;
         }
 
         public void Reset()
@@ -37,12 +37,12 @@ namespace Game.Core
             }
 
             snakeLength = 1;
-            snakeHeadXPos = 15;
-            snakeHeadYPos = 15;
+            snakeHeadXPos = Panel.CenterPoint;
+            snakeHeadYPos = Panel.CenterPoint;
             direction = "left";
             changeToDirection = "left";
-            snakeHeadXPositions[1] = 15;
-            snakeHeadYPositions[1] = 15;
+            snakeHeadXPositions[1] = Panel.CenterPoint;
+            snakeHeadYPositions[1] = Panel.CenterPoint;
         }
 
         public void ProcessDirection(Keys keyData)
@@ -66,7 +66,7 @@ namespace Game.Core
 
         public void boundaryCheck()
         {
-            if (snakeHeadXPos < 0 || snakeHeadXPos > 29 || snakeHeadYPos < 0 || snakeHeadYPos > 29)
+            if (snakeHeadXPos < 0 || snakeHeadXPos >= Panel.PanelSize || snakeHeadYPos < 0 || snakeHeadYPos >= Panel.PanelSize)
                 Game.EndGame();
         }
 

--- a/Snake/main.Designer.cs
+++ b/Snake/main.Designer.cs
@@ -2,6 +2,7 @@
 {
     partial class main
     {
+
         /// <summary>
         /// Required designer variable.
         /// </summary>
@@ -21,6 +22,9 @@
         }
 
         #region Windows Form Designer generated code
+
+        // BoardSize + 4 to the borders
+        public const int BoardSize = 504;
 
         /// <summary>
         /// Required method for Designer support - do not modify
@@ -44,6 +48,7 @@
             // gameTimer
             // 
             this.gameTimer.Enabled = true;
+            this.gameTimer.Interval = 100;
             this.gameTimer.Tick += new System.EventHandler(this.gameTimer_Tick);
             // 
             // EndGameLabel
@@ -65,9 +70,9 @@
             // 
             this.Board.BackColor = System.Drawing.Color.FromArgb(((int)(((byte)(32)))), ((int)(((byte)(34)))), ((int)(((byte)(37)))));
             this.Board.ForeColor = System.Drawing.Color.Red;
-            this.Board.Location = new System.Drawing.Point(34, 112);
+            this.Board.Location = new System.Drawing.Point(27, 105);
             this.Board.Name = "Board";
-            this.Board.Size = new System.Drawing.Size(485, 485);
+            this.Board.Size = new System.Drawing.Size(BoardSize, BoardSize);
             this.Board.TabIndex = 3;
             // 
             // label1
@@ -75,7 +80,7 @@
             this.label1.AutoSize = true;
             this.label1.Font = new System.Drawing.Font("Calibri", 14.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.label1.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(185)))), ((int)(((byte)(187)))), ((int)(((byte)(190)))));
-            this.label1.Location = new System.Drawing.Point(32, 72);
+            this.label1.Location = new System.Drawing.Point(25, 72);
             this.label1.Name = "label1";
             this.label1.Size = new System.Drawing.Size(119, 23);
             this.label1.TabIndex = 15;
@@ -87,7 +92,7 @@
             this.SnakeLengthLabel.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.SnakeLengthLabel.Font = new System.Drawing.Font("Calibri", 20.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.SnakeLengthLabel.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(185)))), ((int)(((byte)(187)))), ((int)(((byte)(190)))));
-            this.SnakeLengthLabel.Location = new System.Drawing.Point(153, 67);
+            this.SnakeLengthLabel.Location = new System.Drawing.Point(153, 61);
             this.SnakeLengthLabel.Name = "SnakeLengthLabel";
             this.SnakeLengthLabel.Size = new System.Drawing.Size(59, 35);
             this.SnakeLengthLabel.TabIndex = 14;
@@ -100,7 +105,7 @@
             this.resetBg.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.resetBg.Font = new System.Drawing.Font("Calibri", 14.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.resetBg.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(185)))), ((int)(((byte)(187)))), ((int)(((byte)(190)))));
-            this.resetBg.Location = new System.Drawing.Point(366, 65);
+            this.resetBg.Location = new System.Drawing.Point(374, 54);
             this.resetBg.Name = "resetBg";
             this.resetBg.Size = new System.Drawing.Size(151, 39);
             this.resetBg.TabIndex = 30;
@@ -113,7 +118,7 @@
             this.restartButton.FlatStyle = System.Windows.Forms.FlatStyle.Flat;
             this.restartButton.Font = new System.Drawing.Font("Calibri", 14.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
             this.restartButton.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(185)))), ((int)(((byte)(187)))), ((int)(((byte)(190)))));
-            this.restartButton.Location = new System.Drawing.Point(367, 66);
+            this.restartButton.Location = new System.Drawing.Point(375, 55);
             this.restartButton.Name = "restartButton";
             this.restartButton.Size = new System.Drawing.Size(149, 37);
             this.restartButton.TabIndex = 31;
@@ -192,5 +197,6 @@
         private System.Windows.Forms.Label label6;
         private System.Windows.Forms.Label closeButton;
         private System.Windows.Forms.Timer foodTimer;
+
     }
 }

--- a/Snake/main.cs
+++ b/Snake/main.cs
@@ -7,6 +7,7 @@ namespace Game
 {
     public partial class main : Form
     {
+
         Snake Snake;
         Core.Panel Panel;
         Food Food;


### PR DESCRIPTION
This PR updates the Board's Panel variables and definitions.
Basically it is now possible to resize the frame and keep it fixed in the same position, just increase and decrease its ratio.

Changing `public static int Size` the Board can increase / decrease, I implemented this to update some constant expressions and for future implementations like increase the difficulty, speed and things like that more easily. 

I also changed the PictureBox for the Panel controller, to more easily implement the Drawning system using `Graphics.DrawRectangle` and the thread system to make it look nicer and with a grater FPS, cause Graphics is updated more than the timer used to do the update. This will also help to load the initialization faster, as it will not be necessary to create each Slot that some part of the snake's body will occupy.